### PR TITLE
Changed Neo4jClient to use properties from file

### DIFF
--- a/neo4j/.gitignore
+++ b/neo4j/.gitignore
@@ -1,0 +1,2 @@
+# ignore the db.properties file 
+/src/main/java/com/yahoo/ycsb/db/db.properties

--- a/neo4j/src/main/java/com/yahoo/ycsb/db/Neo4jClient.java
+++ b/neo4j/src/main/java/com/yahoo/ycsb/db/Neo4jClient.java
@@ -10,7 +10,7 @@ import java.util.Vector;
 import java.util.concurrent.TimeUnit;
 
 import java.io.File;
-
+import java.io.*; 
 import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
@@ -36,13 +36,13 @@ import com.yahoo.ycsb.Status;
 
 public class Neo4jClient extends DB {
 	private static final String URL_PROPERTY         = "neo4j.url";
-  private static final String URL_PROPERTY_DEFAULT = "bolt://localhost:7687";
+  	private static String URL_PROPERTY_DEFAULT = "bolt://localhost:7687";
 
-  private static final String USER_PROPERTY         = "neo4j.user";
-  private static final String USER_PROPERTY_DEFAULT = "neo4j";
+  	private static final String USER_PROPERTY         = "neo4j.user";
+  	private static String USER_PROPERTY_DEFAULT = "neo4j";
 
-  private static final String PASSWORD_PROPERTY         = "neo4j.password";
-  private static final String PASSWORD_PROPERTY_DEFAULT = "1234";
+  	private static final String PASSWORD_PROPERTY         = "neo4j.password";
+  	private static String PASSWORD_PROPERTY_DEFAULT = "1234";
 	/**
   * Initialize any state for this DB. Called once per DB instance; there is one DB instance per client thread.
   */
@@ -64,10 +64,16 @@ public class Neo4jClient extends DB {
 		// initialize Neo4j driver
 		synchronized(Neo4jClient.class) {
 			final Properties props = getProperties();
+			try{
+				FileReader reader=new FileReader("./neo4j/src/main/java/com/yahoo/ycsb/db/db.properties");  
+				props.load(reader);
+			}
+			catch(Exception e){
+				e.printStackTrace();
+			}
 			String url = props.getProperty(URL_PROPERTY, URL_PROPERTY_DEFAULT);
 			String user = props.getProperty(USER_PROPERTY, USER_PROPERTY_DEFAULT);
 			String password = props.getProperty(PASSWORD_PROPERTY, PASSWORD_PROPERTY_DEFAULT);
-
 			if (driver == null) {
 				System.out.println("Making connection");
 

--- a/neo4j/src/main/java/com/yahoo/ycsb/db/db.properties.example
+++ b/neo4j/src/main/java/com/yahoo/ycsb/db/db.properties.example
@@ -1,0 +1,3 @@
+neo4j.url = bolt://localhost:7687
+neo4j.user = your_neo4j_user
+neo4j.password = your_neo4j_password


### PR DESCRIPTION
Changed neo4j client .
Added db.properties.example: use structure to create a db.properties file in the same folder as Neo4jClient.